### PR TITLE
Receiving theme parameter to use the default or github

### DIFF
--- a/bin/code2pdf
+++ b/bin/code2pdf
@@ -5,8 +5,10 @@ require 'optparse'
 $:.push File.expand_path('../../lib', __FILE__)
 require 'code2pdf'
 
+options = {:theme => 'default'}
+
 optparse = OptionParser.new do |opts|
-  opts.banner = "Usage: code2pdf <project path>\n\nYou can use flags as such:"
+  opts.banner = "Usage: code2pdf [OPTIONS] <project path>\n\nYou can use flags as such:"
 
   opts.on('-h', '--help', 'Display this screen') do
     puts opts
@@ -19,6 +21,14 @@ optparse = OptionParser.new do |opts|
     exit
   end
 
+  opts.on("-t", "--theme=github", String, "PDF Theme to use: default or github") do |t|
+    options[:theme] = t
+  end
+
+  opts.on("-f", "--from=DIR", String, "Source dir") do |f|
+    options[:from] = f
+  end
+
   if ARGV.empty?
     puts opts
     exit 1
@@ -26,14 +36,21 @@ optparse = OptionParser.new do |opts|
 end
 
 begin
-  optparse.parse!
+  rest = optparse.parse!
 rescue OptionParser::InvalidOption => exception
   puts exception
   exit 1
 end
 
-PATH = ARGV[0].gsub(/\/$/, '')
+if rest.empty? && options[:from] == nil
+  puts optparse
+  exit 1
+elsif options[:from] == nil
+  options[:from] = rest[0];
+end
+
+PATH = options[:from].gsub(/\/$/, '')
 BLACK_LIST_YAML_FILE = "#{PATH}/.code2pdf".freeze
 
 filename = "#{PATH.gsub(/(\.|\/)/, '_')}.pdf"
-ConvertToPDF.new from: PATH, to: filename, except: BLACK_LIST_YAML_FILE
+ConvertToPDF.new from: PATH, to: filename, except: BLACK_LIST_YAML_FILE, theme: options[:theme]

--- a/lib/code2pdf/convert_to_pdf.rb
+++ b/lib/code2pdf/convert_to_pdf.rb
@@ -14,7 +14,7 @@ class ConvertToPDF
     elsif !params.key?(:to) || params[:to].nil?
       raise ArgumentError.new 'where should I save the generated pdf file?'
     else
-      @from, @to, @except = params[:from], params[:to], params[:except].to_s
+      @from, @to, @except, @themeName = params[:from], params[:to], params[:except].to_s, params[:theme]
 
       if File.exist?(@except) && invalid_blacklist?
         raise LoadError.new "#{@except} is not a valid blacklist YAML file"
@@ -50,10 +50,16 @@ class ConvertToPDF
     file_lexer = Rouge::Lexer.find(file_type)
     return CGI.escapeHTML(file.last) unless file_lexer
 
-    theme = Rouge::Themes::Base16.mode(:light)
+    if (@themeName == "github")
+      theme = Rouge::Themes::Github.new()
+    else
+      theme = Rouge::Themes::Base16.mode(:light)
+    end
+
     formatter = Rouge::Formatters::HTMLInline.new(theme)
     formatter = Rouge::Formatters::HTMLTable.new(formatter, start_line: 1)
     code_data = file.last.encode('UTF-8', 'binary', invalid: :replace, undef: :replace, replace: '')
+    puts "Processing file #{file.first}"
     formatter.format(file_lexer.lex(code_data))
   end
 


### PR DESCRIPTION
Hello!
I facing some issues using the default Rouge theme, then I added a script param to switch to the Github theme (that works fine to me).

`/Users/rafael/.rvm/rubies/ruby-2.6.8/lib/ruby/gems/2.6.0/gems/rouge-2.0.7/lib/rouge/formatters/html_inline.rb:15:in `safe_span': undefined method `style_for' for Rouge::Themes::Base16:Class (NoMethodError)
Did you mean?  style
	from /Users/rafael/.rvm/rubies/ruby-2.6.8/lib/ruby/gems/2.6.0/gems/rouge-2.0.7/lib/rouge/formatters/html.rb:15:in `span'
	from /Users/rafael/.rvm/rubies/ruby-2.6.8/lib/ruby/gems/2.6.0/gems/rouge-2.0.7/lib/rouge/formatters/html_table.rb:30:in `block in stream'
	from /Users/rafael/.rvm/rubies/ruby-2.6.8/lib/ruby/gems/2.6.0/gems/rouge-2.0.7/lib/rouge/lexer.rb:315:in `block in lex'
	from /Users/rafael/.rvm/rubies/ruby-2.6.8/lib/ruby/gems/2.6.0/gems/rouge-2.0.7/lib/rouge/regex_lexer.rb:126:in `block in rule'
	from /Users/rafael/.rvm/rubies/ruby-2.6.8/lib/ruby/gems/2.6.0/gems/rouge-2.0.7/lib/rouge/regex_lexer.rb:305:in `instance_exec'
	from /Users/rafael/.rvm/rubies/ruby-2.6.8/lib/ruby/gems/2.6.0/gems/rouge-2.0.7/lib/rouge/regex_lexer.rb:305:in `block in step'
	from /Users/rafael/.rvm/rubies/ruby-2.6.8/lib/ruby/gems/2.6.0/gems/rouge-2.0.7/lib/rouge/regex_lexer.rb:287:in `each'
	from /Users/rafael/.rvm/rubies/ruby-2.6.8/lib/ruby/gems/2.6.0/gems/rouge-2.0.7/lib/rouge/regex_lexer.rb:287:in `step'
	from /Users/rafael/.rvm/rubies/ruby-2.6.8/lib/ruby/gems/2.6.0/gems/rouge-2.0.7/lib/rouge/regex_lexer.rb:268:in `stream_tokens'
	from /Users/rafael/.rvm/rubies/ruby-2.6.8/lib/ruby/gems/2.6.0/gems/rouge-2.0.7/lib/rouge/lexer.rb:307:in `lex'
	from /Users/rafael/.rvm/rubies/ruby-2.6.8/lib/ruby/gems/2.6.0/gems/rouge-2.0.7/lib/rouge/formatters/html_table.rb:27:in `each'
	from /Users/rafael/.rvm/rubies/ruby-2.6.8/lib/ruby/gems/2.6.0/gems/rouge-2.0.7/lib/rouge/formatters/html_table.rb:27:in `stream'
	from /Users/rafael/.rvm/rubies/ruby-2.6.8/lib/ruby/gems/2.6.0/gems/rouge-2.0.7/lib/rouge/formatter.rb:37:in `format'
	from /Users/rafael/Development/x4fare/code2pdf/lib/code2pdf/convert_to_pdf.rb:63:in `syntax_highlight'
	from /Users/rafael/Development/x4fare/code2pdf/lib/code2pdf/convert_to_pdf.rb:40:in `block in pdf'
	from /Users/rafael/Development/x4fare/code2pdf/lib/code2pdf/convert_to_pdf.rb:38:in `each'
	from /Users/rafael/Development/x4fare/code2pdf/lib/code2pdf/convert_to_pdf.rb:38:in `pdf'
	from /Users/rafael/Development/x4fare/code2pdf/lib/code2pdf/convert_to_pdf.rb:30:in `save'
	from /Users/rafael/Development/x4fare/code2pdf/lib/code2pdf/convert_to_pdf.rb:23:in `initialize'
	from /Users/rafael/Development/x4fare/code2pdf/bin/code2pdf:58:in `new'
	from /Users/rafael/Development/x4fare/code2pdf/bin/code2pdf:58:in `<main>'
`